### PR TITLE
Initial attempt at migrating from bootstrap 4 to 5

### DIFF
--- a/meteor_packages/mats-common/package.js
+++ b/meteor_packages/mats-common/package.js
@@ -15,7 +15,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-    api.versionsFrom('1.4.1.1');
+    api.versionsFrom('2.3.5');
     Npm.depends({
         'fs-extra': '7.0.0',
         "@babel/runtime": "7.10.4",
@@ -24,7 +24,10 @@ Package.onUse(function (api) {
         "jquery-ui": "1.12.1",
         "csv-stringify": "4.3.1",
         "node-file-cache" : "1.0.2",
-        "python-shell": "1.0.8"
+        "python-shell": "1.0.8",
+        "daterangepicker": "3.1.0",
+        "@popperjs/core": "2.9.3",
+        "bootstrap": "5.0.0"
     });
     api.mainModule("server/main.js", "server");
     api.mainModule("client/main.js", "client");
@@ -40,11 +43,11 @@ Package.onUse(function (api) {
     api.use("accounts-ui", 'client');
     api.use("service-configuration", 'server');
     api.use("yasinuslu:json-view", "client");
-    api.use("dangrossman:bootstrap-daterangepicker");
+    // api.use("dangrossman:bootstrap-daterangepicker"); // This needs to be an npm dependency
     api.use("mdg:validated-method");
     api.use('session');
     api.imply('session');
-    api.use("twbs:bootstrap");
+    // api.use("twbs:bootstrap");
     api.use("fortawesome:fontawesome");
     api.use("msavin:mongol");
     api.use("differential:event-hooks");

--- a/meteor_packages/mats-common/templates/common/date_range.js
+++ b/meteor_packages/mats-common/templates/common/date_range.js
@@ -3,6 +3,7 @@
  */
 
 import {matsCollections, matsCurveUtils, matsParamUtils, matsTypes} from 'meteor/randyp:mats-common';
+import {daterangepicker} from 'daterangepicker';
 
 Template.dateRange.onRendered(function () {
     //NOTE: Date fields are special in that they are qualified by plotType.


### PR DESCRIPTION
This results in a broken MATS UI. I've:
- upgraded the "versionsFrom" to use the packages from meteor 2.3.5 instead of 1.4.1.1 (1.4.11?)
- moved the daterangepicker from an atmosphere to npm dependency
- moved bootstrap from an atmosphere to npm dependency