### PR TITLE
Add methods to get version info from the env

### DIFF
--- a/meteor_packages/mats-common/README.md
+++ b/meteor_packages/mats-common/README.md
@@ -1,2 +1,10 @@
-Readme goes here.
+# MATScommon
+
+This is the Meteor Atmosphere package for MATScommon. 
+
+
+## Testing
+
+You can test with something like: `meteor test-packages ./ --driver-package meteortesting:mocha --settings </path/to>/mats-settings/configurations/local/settings/aircraft/settings.json`
+
 

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -4,8 +4,8 @@
 
 import {Meteor} from "meteor/meteor";
 import {ValidatedMethod} from 'meteor/mdg:validated-method';
-import {SimpleSchema} from 'meteor/aldeed:simple-schema';
-import {matsCache, matsCollections, matsDataQueryUtils, matsCouchbaseUtils, matsDataUtils, matsTypes} from 'meteor/randyp:mats-common';
+import SimpleSchema from 'simpl-schema';
+import {matsCache, matsCollections, matsDataQueryUtils, matsCouchbaseUtils, matsDataUtils, matsTypes, versionInfo} from 'meteor/randyp:mats-common';
 import {mysql} from 'meteor/pcel:mysql';
 import {url} from 'url';
 import {Mongo} from 'meteor/mongo';
@@ -1762,23 +1762,29 @@ const resetApp = async function (appRef) {
         if (Meteor.settings.public.undefinedRoles && Meteor.settings.public.undefinedRoles.length > 1) {
             throw new Meteor.Error("dbpools not initialized " + Meteor.settings.public.undefinedRoles);
         }
-        var deployment;
-        var deploymentText = Assets.getText('public/deployment/deployment.json');
-        deployment = JSON.parse(deploymentText);
-        var app = {};
-        // sort through the deployments to find the app that matches this deployment environment that is currently running
-        for (var ai = 0; ai < deployment.length; ai++) {
-            var dep = deployment[ai];
-            if (dep.deployment_environment == dep_env) {
-                app = dep.apps.filter(function (app) {
-                    return app.app === appName;
-                })[0];
+
+        // Try getting Version from env
+        let { version: appVersion, commit: buildDate, branch } = versionInfo.getVersionsFromEnv();
+        if (appVersion === 'Unknown') {
+            // Try getting versionInfo from the appProduction database
+            console.log("VERSION not set in the environment - try getting from deployment.json")
+            var deploymentText = Assets.getText('public/deployment/deployment.json');
+            var deployment = JSON.parse(deploymentText);
+            var app = {};
+            // sort through the deployments to find the app that matches this deployment environment that is currently running
+            for (var ai = 0; ai < deployment.length; ai++) {
+                var dep = deployment[ai];
+                if (dep.deployment_environment == dep_env) {
+                    app = dep.apps.filter(function (app) {
+                        return app.app === appName;
+                    })[0];
+                }
             }
+            appVersion = app ? app.version : "unknown";
+            buildDate = app ? app.buildDate : "unknown";
         }
-        const appVersion = app ? app.version : "unknown";
-        const buildDate = app ? app.buildDate : "unknown";
         const appType = type ? type : matsTypes.AppTypes.mats;
-        matsCollections.appName.upsert({app: appName}, {$set: {app: appName}});
+        matsCollections.appName.upsert({ app: appName }, { $set: { app: appName } });
 
         // remember that we updated the metadata tables just now - create metaDataTableUpdates
         /*

--- a/meteor_packages/mats-common/imports/startup/api/version-info-tests.js
+++ b/meteor_packages/mats-common/imports/startup/api/version-info-tests.js
@@ -1,0 +1,44 @@
+import {versionInfo} from 'meteor/randyp:mats-common';
+var assert = require('assert');
+
+describe('getVersionsFromEnv', function () {
+    let envCache
+
+    // Cache the env before each test
+    beforeEach(function () {
+        envCache = process.env
+    });
+
+    // Reset the env after each test
+    afterEach(function() {
+        Object.keys(process.env).forEach((key) => { delete process.env[key] });
+        Object.entries(envCache).forEach(([ key, value ]) => {
+            if (key !== undefined) {
+                process.env[key] = value;
+            }
+        });
+    });
+
+    // Test
+    it('Correctly reads version from env', function (){
+        process.env.VERSION = "4.2.0";
+        const { version, commit, branch } = versionInfo.getVersionsFromEnv();
+        assert.equal(version, "4.2.0");
+    });
+    it('Correctly reads commit from env', function (){
+        process.env.COMMIT = "ae214rfda";
+        const { version, commit, branch } = versionInfo.getVersionsFromEnv();
+        assert.equal(commit, "ae214rfda");
+    });
+    it('Correctly reads version from env', function (){
+        process.env.BRANCH = "test";
+        const { version, commit, branch } = versionInfo.getVersionsFromEnv();
+        assert.equal(branch, "test");
+    });
+    it('Correctly handles no env', function (){
+        const { version, commit, branch } = versionInfo.getVersionsFromEnv();
+        assert.equal(version, "Unknown");
+        assert.equal(commit, "Unknown");
+        assert.equal(branch, "Unknown");
+    });
+});

--- a/meteor_packages/mats-common/imports/startup/api/version-info-tests.js
+++ b/meteor_packages/mats-common/imports/startup/api/version-info-tests.js
@@ -1,4 +1,4 @@
-import {versionInfo} from 'meteor/randyp:mats-common';
+import { versionInfo } from 'meteor/randyp:mats-common';
 var assert = require('assert');
 
 describe('getVersionsFromEnv', function () {
@@ -10,9 +10,9 @@ describe('getVersionsFromEnv', function () {
     });
 
     // Reset the env after each test
-    afterEach(function() {
+    afterEach(function () {
         Object.keys(process.env).forEach((key) => { delete process.env[key] });
-        Object.entries(envCache).forEach(([ key, value ]) => {
+        Object.entries(envCache).forEach(([key, value]) => {
             if (key !== undefined) {
                 process.env[key] = value;
             }
@@ -20,22 +20,22 @@ describe('getVersionsFromEnv', function () {
     });
 
     // Test
-    it('Correctly reads version from env', function (){
+    it('Correctly reads version from env', function () {
         process.env.VERSION = "4.2.0";
         const { version, commit, branch } = versionInfo.getVersionsFromEnv();
         assert.equal(version, "4.2.0");
     });
-    it('Correctly reads commit from env', function (){
+    it('Correctly reads commit from env', function () {
         process.env.COMMIT = "ae214rfda";
         const { version, commit, branch } = versionInfo.getVersionsFromEnv();
         assert.equal(commit, "ae214rfda");
     });
-    it('Correctly reads version from env', function (){
+    it('Correctly reads version from env', function () {
         process.env.BRANCH = "test";
         const { version, commit, branch } = versionInfo.getVersionsFromEnv();
         assert.equal(branch, "test");
     });
-    it('Correctly handles no env', function (){
+    it('Correctly handles no env', function () {
         const { version, commit, branch } = versionInfo.getVersionsFromEnv();
         assert.equal(version, "Unknown");
         assert.equal(commit, "Unknown");

--- a/meteor_packages/mats-common/imports/startup/api/version-info.js
+++ b/meteor_packages/mats-common/imports/startup/api/version-info.js
@@ -1,0 +1,25 @@
+/**
+ * Get versioning info from the environment
+ * 
+ * Returns "Unknown" if no value found
+ * 
+ * @returns {{
+ *  version: String
+ *  commit: String
+ *  branch: String
+ * }}
+ */
+function getVersionsFromEnv() {
+    const VERSION = process.env.VERSION || "Unknown";
+    const COMMIT = process.env.COMMIT || "Unknown";
+    const BRANCH = process.env.BRANCH || "Unknown";
+    return {
+        version: VERSION,
+        commit: COMMIT,
+        branch: BRANCH
+    }
+}
+
+export default versionInfo = {
+    getVersionsFromEnv: getVersionsFromEnv
+};

--- a/meteor_packages/mats-common/imports/startup/client/routes.js
+++ b/meteor_packages/mats-common/imports/startup/client/routes.js
@@ -133,10 +133,9 @@ FlowRouter.route(Meteor.settings.public.proxy_prefix_path + '/*/', {
     }
 });
 
-FlowRouter.route('*', {
+FlowRouter.route('/*', {
     action() {
         console.log ('route: ' + ' not found' );
         this.render('notFound');
     }
 });
-

--- a/meteor_packages/mats-common/package.js
+++ b/meteor_packages/mats-common/package.js
@@ -15,7 +15,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-    api.versionsFrom('1.4.1.1');
+    api.versionsFrom('2.4');
     Npm.depends({
         'fs-extra': '7.0.0',
         "@babel/runtime": "7.10.4",
@@ -24,13 +24,12 @@ Package.onUse(function (api) {
         "jquery-ui": "1.12.1",
         "csv-stringify": "4.3.1",
         "node-file-cache" : "1.0.2",
-        "python-shell": "1.0.8"
+        "python-shell": "1.0.8",
+        "simpl-schema": "1.12.0"
     });
     api.mainModule("server/main.js", "server");
     api.mainModule("client/main.js", "client");
     api.use('natestrauser:select2', 'client');
-    api.use('aldeed:simple-schema');
-    api.imply('aldeed:simple-schema');
     api.use('mdg:validated-method');
     api.use('ecmascript');
     api.use('modules');
@@ -57,6 +56,8 @@ Package.onUse(function (api) {
     api.use("check");
     api.use("ostrio:flow-router-extra");
     api.use("meteorhacks:picker");
+    api.use("momentjs:moment");
+    api.use("pcel:mysql");
 
     // modules
     api.export("matsCollections", ['client', 'server']);
@@ -78,6 +79,7 @@ Package.onUse(function (api) {
     api.export("matsDataProcessUtils", ['server']);
     api.export("regression", ['client', 'server']);
     api.export("matsCache", ['server']);
+    api.export("versionInfo", ['server', 'client']);
 
     // add imports
     //both
@@ -87,6 +89,7 @@ Package.onUse(function (api) {
 
     //api
     api.addFiles('imports/startup/api/matsMethods.js');
+    api.addFiles('imports/startup/api/version-info.js');
 
     //layouts
     api.addFiles("imports/startup/ui/layouts/notFound.html", "client");
@@ -258,7 +261,51 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
     api.use('ecmascript');
-    api.use('tinytest');
+    api.use('meteortesting:mocha');
     api.use('randyp:mats-common');
-    api.addFiles('mats-common-tests.js');
+    api.addFiles('imports/startup/api/version-info-tests.js');
+
+    // try duplicating the runtime deps
+    Npm.depends({
+        'fs-extra': '7.0.0',
+        "@babel/runtime": "7.10.4",
+        "meteor-node-stubs": "0.4.1",
+        "url": "0.11.0",
+        "jquery-ui": "1.12.1",
+        "csv-stringify": "4.3.1",
+        "node-file-cache" : "1.0.2",
+        "python-shell": "1.0.8",
+        "simpl-schema": "1.12.0"
+    });
+    api.use('natestrauser:select2', 'client');
+    // api.use('aldeed:simple-schema');
+    // api.imply('aldeed:simple-schema');
+    api.use('mdg:validated-method');
+    api.use('ecmascript');
+    api.use('modules');
+    api.imply('ecmascript');
+    api.use(['templating'], 'client');
+    api.use("accounts-google", 'client');
+    api.use("accounts-ui", 'client');
+    api.use("service-configuration", 'server');
+    api.use("yasinuslu:json-view", "client");
+    api.use("dangrossman:bootstrap-daterangepicker");
+    api.use("mdg:validated-method");
+    api.use('session');
+    api.imply('session');
+    api.use("twbs:bootstrap");
+    api.use("fortawesome:fontawesome");
+    api.use("msavin:mongol");
+    api.use("differential:event-hooks");
+    api.use("risul:bootstrap-colorpicker");
+    api.use("logging");
+    api.use("reload");
+    api.use("random");
+    api.use("ejson");
+    api.use("spacebars");
+    api.use("check");
+    api.use("ostrio:flow-router-extra");
+    api.use("meteorhacks:picker");
+    api.use("momentjs:moment");
+    api.use("pcel:mysql");
 });

--- a/meteor_packages/mats-common/package.js
+++ b/meteor_packages/mats-common/package.js
@@ -15,7 +15,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-    api.versionsFrom('2.4');
+    api.versionsFrom('2.3');
     Npm.depends({
         'fs-extra': '7.0.0',
         "@babel/runtime": "7.10.4",

--- a/meteor_packages/mats-common/package.js
+++ b/meteor_packages/mats-common/package.js
@@ -278,8 +278,6 @@ Package.onTest(function (api) {
         "simpl-schema": "1.12.0"
     });
     api.use('natestrauser:select2', 'client');
-    // api.use('aldeed:simple-schema');
-    // api.imply('aldeed:simple-schema');
     api.use('mdg:validated-method');
     api.use('ecmascript');
     api.use('modules');


### PR DESCRIPTION
Additionally, add unit tests for the new function. In the process, I
discovered:
* simple-schema was deprecated in favor of the NPM version
* the package was depending on old version of meteor
* the package didn't capture its dependencies on momentjs & pcel:mysql