### PR TITLE
Feature mode bugfix

### DIFF
--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -1547,6 +1547,9 @@ const resetApp = async function (appRef) {
         var curve_params = Meteor.settings.public.curve_params ? Meteor.settings.public.curve_params : [];
         var mapboxKey = "undefined";
 
+        // see if there's any messages to display to the users
+        const appMessage = Meteor.settings.public.alert_message ? Meteor.settings.public.alert_message : undefined;
+
         // if there isn't an app listing in matsCollections create one here so that the configuration-> applySettingsData won't fail
         if (matsCollections.appName.findOne({}) == undefined) {
             matsCollections.appName.upsert({app: appName}, {$set: {app: appName}});
@@ -1605,8 +1608,6 @@ const resetApp = async function (appRef) {
         if (Meteor.settings.private && Meteor.settings.private.MAPBOX_KEY) {
             mapboxKey = Meteor.settings.private.MAPBOX_KEY;
         }
-        // timeout in seconds
-        var connectionTimeout = Meteor.settings.public.mysql_wait_timeout != undefined ? Meteor.settings.public.mysql_wait_timeout : 300;
         delete Meteor.settings.public.undefinedRoles;
         for (var pi = 0; pi < appPools.length; pi++) {
             const record = appPools[pi];
@@ -1634,7 +1635,7 @@ const resetApp = async function (appRef) {
                     // default to mysql so that old apps won't break
                     global[poolName].on('connection', function (connection) {
                         connection.query('set group_concat_max_len = 4294967295');
-                        connection.query('set session wait_timeout = ' + connectionTimeout);
+                        connection.query('set session wait_timeout = ' + appTimeOut);
                         //("opening new " + poolName + " connection");
                     });
                 }
@@ -1708,7 +1709,7 @@ const resetApp = async function (appRef) {
         matsCollections.ColorScheme.remove({});
         matsDataUtils.doColorScheme();
         matsCollections.Settings.remove({});
-        matsDataUtils.doSettings(appTitle, dbType, appVersion, buildDate, appType, mapboxKey, appDefaultGroup, appDefaultDB, appDefaultModel, thresholdUnits);
+        matsDataUtils.doSettings(appTitle, dbType, appVersion, buildDate, appType, mapboxKey, appDefaultGroup, appDefaultDB, appDefaultModel, thresholdUnits, appMessage);
         matsCollections.PlotParams.remove({});
         matsCollections.CurveTextPatterns.remove({});
         // get the curve params for this app out of the settings file

--- a/meteor_packages/mats-common/imports/startup/server/data_util.js
+++ b/meteor_packages/mats-common/imports/startup/server/data_util.js
@@ -293,7 +293,7 @@ const doRoles = function () {
 };
 
 // for use in matsMethods.resetApp() to establish default settings
-const doSettings = function (title, dbType, version, buildDate, appType, mapboxKey, appDefaultGroup, appDefaultDB, appDefaultModel, thresholdUnits) {
+const doSettings = function (title, dbType, version, buildDate, appType, mapboxKey, appDefaultGroup, appDefaultDB, appDefaultModel, thresholdUnits, appMessage) {
     if (matsCollections.Settings.findOne({}) === undefined || matsCollections.Settings.findOne({}).resetFromCode === undefined || matsCollections.Settings.findOne({}).resetFromCode == true) {
         matsCollections.Settings.remove({});
     }
@@ -312,7 +312,8 @@ const doSettings = function (title, dbType, version, buildDate, appType, mapboxK
             appDefaultGroup: appDefaultGroup,
             appDefaultDB: appDefaultDB,
             appDefaultModel: appDefaultModel,
-            thresholdUnits: thresholdUnits
+            thresholdUnits: thresholdUnits,
+            appMessage: appMessage
         });
     }
     // always update the version, roles, and the hostname, not just if it doesn't exist...

--- a/meteor_packages/mats-common/public/MATSReleaseNotes.html
+++ b/meteor_packages/mats-common/public/MATSReleaseNotes.html
@@ -8,6 +8,7 @@
     <p style="margin: 25px 0;"></p>
     <p>Changes: </p>
     <p>* Fixed bug in MET Objects causing the error message "Error from verification query: Error choosing statistic: ..." to occasionally appear.</p>
+    <p>* Added ability for apps to display an alert message defined in settings.</p>
 </div>
 <div>
     <hr style="display: block; height: 2px; margin: 1em 0; border-top: 2px solid #000000;"/>

--- a/meteor_packages/mats-common/public/MATSReleaseNotes.html
+++ b/meteor_packages/mats-common/public/MATSReleaseNotes.html
@@ -4,10 +4,10 @@
 <div>
     <p><h4>Production build date: <x-cr>Current revision</x-cr></h4>
     <p style="margin: 25px 0;"></p>
-    <p><h4>PUT APP VERSIONS HERE</h4>
+    <p><h4>All apps v4.4.2</h4>
     <p style="margin: 25px 0;"></p>
     <p>Changes: </p>
-    <p>* PUT CHANGES HERE</p>
+    <p>* Fixed bug in MET Objects causing the error message "Error from verification query: Error choosing statistic: ..." to occasionally appear.</p>
 </div>
 <div>
     <hr style="display: block; height: 2px; margin: 1em 0; border-top: 2px solid #000000;"/>

--- a/meteor_packages/mats-common/public/python/mode_stats.py
+++ b/meteor_packages/mats-common/public/python/mode_stats.py
@@ -81,6 +81,8 @@ def calculate_ots(sub_interest, sub_pair_fid, sub_pair_oid, sub_mode_header_id, 
                 this_mode_header_id = str(sorted_mode_header[i])
                 this_fid = sorted_fid[i]
                 this_oid = sorted_oid[i]
+                if this_mode_header_id not in individual_obj_lookup:
+                    continue
                 f_area = individual_obj_lookup[this_mode_header_id][this_fid]["area"]
                 o_area = individual_obj_lookup[this_mode_header_id][this_oid]["area"]
                 if this_mode_header_id not in matched_fid.keys():
@@ -181,6 +183,8 @@ def calculate_mcd(sub_interest, sub_pair_fid, sub_pair_oid, sub_mode_header_id, 
                 this_fid = sorted_fid[i]
                 this_oid = sorted_oid[i]
                 this_cent_dist = sorted_cent_dist[i]
+                # if this_mode_header_id not in individual_obj_lookup:
+                #     continue
                 # f_lat = individual_obj_lookup[this_mode_header_id][this_fid]["centroid_lat"]
                 # o_lat = individual_obj_lookup[this_mode_header_id][this_oid]["centroid_lat"]
                 # f_lon = individual_obj_lookup[this_mode_header_id][this_fid]["centroid_lon"]

--- a/meteor_packages/mats-common/templates/plotType/plot_type.html
+++ b/meteor_packages/mats-common/templates/plotType/plot_type.html
@@ -3,6 +3,9 @@
         <div class="row text-center">
             <span style="align-content:center;font-size:xx-large; font-weight: bold;">{{title}}</span>
         </div>
+        <div id="alertMessage" class="row text-center" style="display:{{alertMessageHidden}}">
+            <span style="color: red; font-size: large;">{{alertMessage}}<br/><br/></span>
+        </div>
         <div class="row well well-sm pull-left">
             {{#each plotTypes}}
                 <span style="display: inline-block"><input class="plot-type-{{plotType}}" type=radio name="plot-type" id="plot-type-{{plotType}}" {{display}} value="{{plotType}}" checked={{checked}} /> <label style="font-size: large;">{{plotType}}&nbsp;&nbsp;</label></span>

--- a/meteor_packages/mats-common/templates/plotType/plot_type.js
+++ b/meteor_packages/mats-common/templates/plotType/plot_type.js
@@ -25,6 +25,22 @@ Template.plotType.helpers({
         } else {
             return "";
         }
+    },
+    alertMessageHidden: function () {
+        const alertMessage = matsCollections.Settings.findOne({}).appMessage;
+        if (alertMessage === undefined || alertMessage === "") {
+            return "none";
+        } else {
+            return "block";
+        }
+    },
+    alertMessage: function () {
+        const alertMessage = matsCollections.Settings.findOne({}).appMessage;
+        if (alertMessage === undefined || alertMessage === "") {
+            return "";
+        } else {
+            return alertMessage;
+        }
     }
 });
 


### PR DESCRIPTION
There are two changes in this pull request:

1. A critical bug fix for MET Objects (the edits in the python code). Apparently data can exist in the mode_obj_pairs table in the database without also existing in mode_obj_single. This doesn't seem like it should be possible, so maybe our data loading from Jet got interrupted at some point and caused this, but METexpress should be able to handle it regardless. It now checks to make sure that both table entries exist before proceeding.
2. MATS and METexpress can now display messages from their settings.json files on their app main pages (the javascript edits). Dave suggested this as a way to warn users that MET Objects is being slow on virtual machines. If we want to remove the message later, we just delete it from the settings file.