### PR TITLE
Bump the default Meteor version to 2.7

### DIFF
--- a/meteor_packages/mats-common/package.js
+++ b/meteor_packages/mats-common/package.js
@@ -15,7 +15,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-    api.versionsFrom('2.3');
+    api.versionsFrom('2.7');
     Npm.depends({
         'fs-extra': '7.0.0',
         "@babel/runtime": "7.10.4",


### PR DESCRIPTION
This way we use the latest version of the core packages unless we
override the version in the import statement in `api.use()`.