### PR TITLE
Remove OS-specific packages from npm-shrinkwrap

### DIFF
--- a/meteor_packages/mats-common/.npm/package/npm-shrinkwrap.json
+++ b/meteor_packages/mats-common/.npm/package/npm-shrinkwrap.json
@@ -6,16 +6,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
       "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ=="
     },
-    "@couchbase/couchbase-darwin-x64-openssl1": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-openssl1/-/couchbase-darwin-x64-openssl1-4.2.5.tgz",
-      "integrity": "sha512-EaekT3/LVlXI5w/1S8HnQV6rrQ8TLbIv/I3XeOjC8Z7JurGYeML/gXRiWSP87cUx0pHk/tvEDiWJD7nVpBTHcQ=="
-    },
-    "@couchbase/couchbase-darwin-x64-openssl3": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-openssl3/-/couchbase-darwin-x64-openssl3-4.2.5.tgz",
-      "integrity": "sha512-KzGlEd9+NPmlOXA5jfS/j9kFbrE78wIFvta5OWlWvsccPEeVK49bIzY1g6Hrd3I9V32hjYJsgDIwZZ2bI1i//g=="
-    },
     "@fortawesome/fontawesome-free": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz",


### PR DESCRIPTION
This was causing our container images to rebuild Couchbase from source and vastly increasing the size of our image by multiple GB.