### PR TITLE
Refactor routing

### DIFF
--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -42,11 +42,7 @@ const isEmpty = function (map) {
 // private middleware for determining if the app is running
 const getHealth = async function (res) {
   if (Meteor.isServer) {
-    const settings = await matsCollections.Settings.findOneAsync();
-    res.status(200).json({
-      status: "Ok",
-      version: settings.appVersion,
-    });
+    res.sendStatus(200);
   }
 };
 

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -2958,6 +2958,8 @@ if (Meteor.isServer) {
     Meteor.settings.public.proxy_prefix_path = "";
   }
 
+  const proxyPrefixPath = Meteor.settings.public.proxy_prefix_path;
+
   // needed for middleware routes
   const app = WebApp.express();
   const router = WebApp.express.Router();
@@ -2966,118 +2968,88 @@ if (Meteor.isServer) {
     await status(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/status`,
-    async (req, res, next) => {
-      await status(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/status`, async (req, res, next) => {
+    await status(res);
+  });
 
   router.use("/CSV/:f/:key/:m/:a", (req, res, next) => {
     getCSV(req.params, res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/CSV/:f/:key/:m/:a`,
-    (req, res, next) => {
-      getCSV(req.params, res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/CSV/:f/:key/:m/:a`, (req, res, next) => {
+    getCSV(req.params, res);
+  });
 
   router.use("/JSON/:f/:key/:m/:a", (req, res, next) => {
     getJSON(req.params, res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/JSON/:f/:key/:m/:a`,
-    (req, res, next) => {
-      getJSON(req.params, res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/JSON/:f/:key/:m/:a`, (req, res, next) => {
+    getJSON(req.params, res);
+  });
 
   router.use("/clearCache", (req, res, next) => {
     clearCache(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/clearCache`,
-    (req, res, next) => {
-      clearCache(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/clearCache`, (req, res, next) => {
+    clearCache(res);
+  });
 
   router.use("/getApps", async (req, res, next) => {
     await getApps(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getApps`,
-    async (req, res, next) => {
-      await getApps(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getApps`, async (req, res, next) => {
+    await getApps(res);
+  });
 
   router.use("/getAppSumsDBs", async (req, res, next) => {
     await getAppSumsDBs(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getAppSumsDBs`,
-    async (req, res, next) => {
-      await getAppSumsDBs(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getAppSumsDBs`, async (req, res, next) => {
+    await getAppSumsDBs(res);
+  });
 
   router.use("/getModels", async (req, res, next) => {
     await getModels(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getModels`,
-    async (req, res, next) => {
-      await getModels(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getModels`, async (req, res, next) => {
+    await getModels(res);
+  });
 
   router.use("/getRegions", async (req, res, next) => {
     await getRegions(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getRegions`,
-    async (req, res, next) => {
-      await getRegions(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getRegions`, async (req, res, next) => {
+    await getRegions(res);
+  });
 
   router.use("/getRegionsValuesMap", async (req, res, next) => {
     await getRegionsValuesMap(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getRegionsValuesMap`,
-    async (req, res, next) => {
-      await getRegionsValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getRegionsValuesMap`, async (req, res, next) => {
+    await getRegionsValuesMap(res);
+  });
 
   router.use("/getStatistics", async (req, res, next) => {
     await getStatistics(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getStatistics`,
-    async (req, res, next) => {
-      await getStatistics(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getStatistics`, async (req, res, next) => {
+    await getStatistics(res);
+  });
 
   router.use("/getStatisticsValuesMap", async (req, res, next) => {
     await getStatisticsValuesMap(res);
   });
 
   router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getStatisticsValuesMap`,
+    `${proxyPrefixPath}/:app/getStatisticsValuesMap`,
     async (req, res, next) => {
       await getStatisticsValuesMap(res);
     }
@@ -3087,19 +3059,16 @@ if (Meteor.isServer) {
     await getVariables(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getVariables`,
-    async (req, res, next) => {
-      await getVariables(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getVariables`, async (req, res, next) => {
+    await getVariables(res);
+  });
 
   router.use("/getVariablesValuesMap", async (req, res, next) => {
     await getVariablesValuesMap(res);
   });
 
   router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getVariablesValuesMap`,
+    `${proxyPrefixPath}/:app/getVariablesValuesMap`,
     async (req, res, next) => {
       await getVariablesValuesMap(res);
     }
@@ -3109,19 +3078,16 @@ if (Meteor.isServer) {
     await getThresholds(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getThresholds`,
-    async (req, res, next) => {
-      await getThresholds(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getThresholds`, async (req, res, next) => {
+    await getThresholds(res);
+  });
 
   router.use("/getThresholdsValuesMap", async (req, res, next) => {
     await getThresholdsValuesMap(res);
   });
 
   router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getThresholdsValuesMap`,
+    `${proxyPrefixPath}/:app/getThresholdsValuesMap`,
     async (req, res, next) => {
       await getThresholdsValuesMap(res);
     }
@@ -3131,74 +3097,56 @@ if (Meteor.isServer) {
     await getScales(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getScales`,
-    async (req, res, next) => {
-      await getScales(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getScales`, async (req, res, next) => {
+    await getScales(res);
+  });
 
   router.use("/getScalesValuesMap", async (req, res, next) => {
     await getScalesValuesMap(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getScalesValuesMap`,
-    async (req, res, next) => {
-      await getScalesValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getScalesValuesMap`, async (req, res, next) => {
+    await getScalesValuesMap(res);
+  });
 
   router.use("/getTruths", async (req, res, next) => {
     await getTruths(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getTruths`,
-    async (req, res, next) => {
-      await getTruths(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getTruths`, async (req, res, next) => {
+    await getTruths(res);
+  });
 
   router.use("/getTruthsValuesMap", async (req, res, next) => {
     await getTruthsValuesMap(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getTruthsValuesMap`,
-    async (req, res, next) => {
-      await getTruthsValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getTruthsValuesMap`, async (req, res, next) => {
+    await getTruthsValuesMap(res);
+  });
 
   router.use("/getFcstLengths", async (req, res, next) => {
     await getFcstLengths(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getFcstLengths`,
-    async (req, res, next) => {
-      await getFcstLengths(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getFcstLengths`, async (req, res, next) => {
+    await getFcstLengths(res);
+  });
 
   router.use("/getFcstTypes", async (req, res, next) => {
     await getFcstTypes(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getFcstTypes`,
-    async (req, res, next) => {
-      await getFcstTypes(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getFcstTypes`, async (req, res, next) => {
+    await getFcstTypes(res);
+  });
 
   router.use("/getFcstTypesValuesMap", async (req, res, next) => {
     await getFcstTypesValuesMap(res);
   });
 
   router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getFcstTypesValuesMap`,
+    `${proxyPrefixPath}/:app/getFcstTypesValuesMap`,
     async (req, res, next) => {
       await getFcstTypesValuesMap(res);
     }
@@ -3208,67 +3156,49 @@ if (Meteor.isServer) {
     await getValidTimes(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getValidTimes`,
-    async (req, res, next) => {
-      await getValidTimes(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getValidTimes`, async (req, res, next) => {
+    await getValidTimes(res);
+  });
 
   router.use("/getLevels", async (req, res, next) => {
     await getLevels(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getLevels`,
-    async (req, res, next) => {
-      await getLevels(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getLevels`, async (req, res, next) => {
+    await getLevels(res);
+  });
 
   router.use("/getDates", async (req, res, next) => {
     await getDates(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/getDates`,
-    async (req, res, next) => {
-      await getDates(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getDates`, async (req, res, next) => {
+    await getDates(res);
+  });
 
   router.use("/refreshMetadata", async (req, res, next) => {
     await refreshMetadataMWltData(res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/refreshMetadata`,
-    async (req, res, next) => {
-      await refreshMetadataMWltData(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/refreshMetadata`, async (req, res, next) => {
+    await refreshMetadataMWltData(res);
+  });
 
   router.use("/refreshScorecard/:docId", (req, res, next) => {
     refreshScorecard(req.params, res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/refreshScorecard/:docId`,
-    (req, res, next) => {
-      refreshScorecard(req.params, res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/refreshScorecard/:docId`, (req, res, next) => {
+    refreshScorecard(req.params, res);
+  });
 
   router.use("/setStatusScorecard/:docId", (req, res, next) => {
     setStatusScorecard(req.params, req, res);
   });
 
-  router.use(
-    `${Meteor.settings.public.proxy_prefix_path}/:app/setStatusScorecard/:docId`,
-    (req, res, next) => {
-      setStatusScorecard(req.params, req, res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/setStatusScorecard/:docId`, (req, res, next) => {
+    setStatusScorecard(req.params, req, res);
+  });
 
   // mount the router on the app
   app.use("/", router);

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -2964,239 +2964,227 @@ if (Meteor.isServer) {
   const app = WebApp.express();
   const router = WebApp.express.Router();
 
-  router.use("/status", async (req, res, next) => {
+  router.use("/status", async (req, res) => {
     await status(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/status`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/status`, async (req, res) => {
     await status(res);
   });
 
-  router.use("/CSV/:f/:key/:m/:a", (req, res, next) => {
+  router.use("/CSV/:f/:key/:m/:a", (req, res) => {
     getCSV(req.params, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/CSV/:f/:key/:m/:a`, (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/CSV/:f/:key/:m/:a`, (req, res) => {
     getCSV(req.params, res);
   });
 
-  router.use("/JSON/:f/:key/:m/:a", (req, res, next) => {
+  router.use("/JSON/:f/:key/:m/:a", (req, res) => {
     getJSON(req.params, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/JSON/:f/:key/:m/:a`, (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/JSON/:f/:key/:m/:a`, (req, res) => {
     getJSON(req.params, res);
   });
 
-  router.use("/clearCache", (req, res, next) => {
+  router.use("/clearCache", (req, res) => {
     clearCache(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/clearCache`, (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/clearCache`, (req, res) => {
     clearCache(res);
   });
 
-  router.use("/getApps", async (req, res, next) => {
+  router.use("/getApps", async (req, res) => {
     await getApps(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getApps`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getApps`, async (req, res) => {
     await getApps(res);
   });
 
-  router.use("/getAppSumsDBs", async (req, res, next) => {
+  router.use("/getAppSumsDBs", async (req, res) => {
     await getAppSumsDBs(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getAppSumsDBs`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getAppSumsDBs`, async (req, res) => {
     await getAppSumsDBs(res);
   });
 
-  router.use("/getModels", async (req, res, next) => {
+  router.use("/getModels", async (req, res) => {
     await getModels(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getModels`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getModels`, async (req, res) => {
     await getModels(res);
   });
 
-  router.use("/getRegions", async (req, res, next) => {
+  router.use("/getRegions", async (req, res) => {
     await getRegions(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getRegions`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getRegions`, async (req, res) => {
     await getRegions(res);
   });
 
-  router.use("/getRegionsValuesMap", async (req, res, next) => {
+  router.use("/getRegionsValuesMap", async (req, res) => {
     await getRegionsValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getRegionsValuesMap`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getRegionsValuesMap`, async (req, res) => {
     await getRegionsValuesMap(res);
   });
 
-  router.use("/getStatistics", async (req, res, next) => {
+  router.use("/getStatistics", async (req, res) => {
     await getStatistics(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getStatistics`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getStatistics`, async (req, res) => {
     await getStatistics(res);
   });
 
-  router.use("/getStatisticsValuesMap", async (req, res, next) => {
+  router.use("/getStatisticsValuesMap", async (req, res) => {
     await getStatisticsValuesMap(res);
   });
 
-  router.use(
-    `${proxyPrefixPath}/:app/getStatisticsValuesMap`,
-    async (req, res, next) => {
-      await getStatisticsValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getStatisticsValuesMap`, async (req, res) => {
+    await getStatisticsValuesMap(res);
+  });
 
-  router.use("/getVariables", async (req, res, next) => {
+  router.use("/getVariables", async (req, res) => {
     await getVariables(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getVariables`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getVariables`, async (req, res) => {
     await getVariables(res);
   });
 
-  router.use("/getVariablesValuesMap", async (req, res, next) => {
+  router.use("/getVariablesValuesMap", async (req, res) => {
     await getVariablesValuesMap(res);
   });
 
-  router.use(
-    `${proxyPrefixPath}/:app/getVariablesValuesMap`,
-    async (req, res, next) => {
-      await getVariablesValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getVariablesValuesMap`, async (req, res) => {
+    await getVariablesValuesMap(res);
+  });
 
-  router.use("/getThresholds", async (req, res, next) => {
+  router.use("/getThresholds", async (req, res) => {
     await getThresholds(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getThresholds`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getThresholds`, async (req, res) => {
     await getThresholds(res);
   });
 
-  router.use("/getThresholdsValuesMap", async (req, res, next) => {
+  router.use("/getThresholdsValuesMap", async (req, res) => {
     await getThresholdsValuesMap(res);
   });
 
-  router.use(
-    `${proxyPrefixPath}/:app/getThresholdsValuesMap`,
-    async (req, res, next) => {
-      await getThresholdsValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getThresholdsValuesMap`, async (req, res) => {
+    await getThresholdsValuesMap(res);
+  });
 
-  router.use("/getScales", async (req, res, next) => {
+  router.use("/getScales", async (req, res) => {
     await getScales(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getScales`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getScales`, async (req, res) => {
     await getScales(res);
   });
 
-  router.use("/getScalesValuesMap", async (req, res, next) => {
+  router.use("/getScalesValuesMap", async (req, res) => {
     await getScalesValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getScalesValuesMap`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getScalesValuesMap`, async (req, res) => {
     await getScalesValuesMap(res);
   });
 
-  router.use("/getTruths", async (req, res, next) => {
+  router.use("/getTruths", async (req, res) => {
     await getTruths(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getTruths`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getTruths`, async (req, res) => {
     await getTruths(res);
   });
 
-  router.use("/getTruthsValuesMap", async (req, res, next) => {
+  router.use("/getTruthsValuesMap", async (req, res) => {
     await getTruthsValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getTruthsValuesMap`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getTruthsValuesMap`, async (req, res) => {
     await getTruthsValuesMap(res);
   });
 
-  router.use("/getFcstLengths", async (req, res, next) => {
+  router.use("/getFcstLengths", async (req, res) => {
     await getFcstLengths(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getFcstLengths`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getFcstLengths`, async (req, res) => {
     await getFcstLengths(res);
   });
 
-  router.use("/getFcstTypes", async (req, res, next) => {
+  router.use("/getFcstTypes", async (req, res) => {
     await getFcstTypes(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getFcstTypes`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getFcstTypes`, async (req, res) => {
     await getFcstTypes(res);
   });
 
-  router.use("/getFcstTypesValuesMap", async (req, res, next) => {
+  router.use("/getFcstTypesValuesMap", async (req, res) => {
     await getFcstTypesValuesMap(res);
   });
 
-  router.use(
-    `${proxyPrefixPath}/:app/getFcstTypesValuesMap`,
-    async (req, res, next) => {
-      await getFcstTypesValuesMap(res);
-    }
-  );
+  router.use(`${proxyPrefixPath}/:app/getFcstTypesValuesMap`, async (req, res) => {
+    await getFcstTypesValuesMap(res);
+  });
 
-  router.use("/getValidTimes", async (req, res, next) => {
+  router.use("/getValidTimes", async (req, res) => {
     await getValidTimes(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getValidTimes`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getValidTimes`, async (req, res) => {
     await getValidTimes(res);
   });
 
-  router.use("/getLevels", async (req, res, next) => {
+  router.use("/getLevels", async (req, res) => {
     await getLevels(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getLevels`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getLevels`, async (req, res) => {
     await getLevels(res);
   });
 
-  router.use("/getDates", async (req, res, next) => {
+  router.use("/getDates", async (req, res) => {
     await getDates(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getDates`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/getDates`, async (req, res) => {
     await getDates(res);
   });
 
-  router.use("/refreshMetadata", async (req, res, next) => {
+  router.use("/refreshMetadata", async (req, res) => {
     await refreshMetadataMWltData(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/refreshMetadata`, async (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/refreshMetadata`, async (req, res) => {
     await refreshMetadataMWltData(res);
   });
 
-  router.use("/refreshScorecard/:docId", (req, res, next) => {
+  router.use("/refreshScorecard/:docId", (req, res) => {
     refreshScorecard(req.params, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/refreshScorecard/:docId`, (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/refreshScorecard/:docId`, (req, res) => {
     refreshScorecard(req.params, res);
   });
 
-  router.use("/setStatusScorecard/:docId", (req, res, next) => {
+  router.use("/setStatusScorecard/:docId", (req, res) => {
     setStatusScorecard(req.params, req, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/setStatusScorecard/:docId`, (req, res, next) => {
+  router.use(`${proxyPrefixPath}/:app/setStatusScorecard/:docId`, (req, res) => {
     setStatusScorecard(req.params, req, res);
   });
 

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -39,13 +39,14 @@ const isEmpty = function (map) {
   return mapKeys.length === 0;
 };
 
-// private middleware for getting the status - think health check
-const status = async function (res) {
+// private middleware for determining if the app is running
+const getHealth = async function (res) {
   if (Meteor.isServer) {
     const settings = await matsCollections.Settings.findOneAsync();
-    res.end(
-      `<body><div id='status'>Running: version - ${settings.appVersion} </div></body>`
-    );
+    res.status(200).json({
+      status: "Ok",
+      version: settings.appVersion,
+    });
   }
 };
 
@@ -2964,12 +2965,12 @@ if (Meteor.isServer) {
   const app = WebApp.express();
   const router = WebApp.express.Router();
 
-  router.use("/status", async (req, res) => {
-    await status(res);
+  router.use("/healthz", async (req, res) => {
+    await getHealth(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/status`, async (req, res) => {
-    await status(res);
+  router.use(`${proxyPrefixPath}/:app/healthz`, async (req, res) => {
+    await getHealth(res);
   });
 
   router.use("/CSV/:f/:key/:m/:a", (req, res) => {

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -2962,366 +2962,310 @@ if (Meteor.isServer) {
   const app = WebApp.express();
   const router = WebApp.express.Router();
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/status", async function (req, res, next) {
+  router.use("/status", async (req, res, next) => {
     await status(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/status`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await status(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/CSV/:f/:key/:m/:a", function (req, res, next) {
+  router.use("/CSV/:f/:key/:m/:a", (req, res, next) => {
     getCSV(req.params, res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/CSV/:f/:key/:m/:a`,
-    // eslint-disable-next-line no-unused-vars
-    function (req, res, next) {
+    (req, res, next) => {
       getCSV(req.params, res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/JSON/:f/:key/:m/:a", function (req, res, next) {
+  router.use("/JSON/:f/:key/:m/:a", (req, res, next) => {
     getJSON(req.params, res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/JSON/:f/:key/:m/:a`,
-    // eslint-disable-next-line no-unused-vars
-    function (req, res, next) {
+    (req, res, next) => {
       getJSON(req.params, res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/clearCache", function (req, res, next) {
+  router.use("/clearCache", (req, res, next) => {
     clearCache(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/clearCache`,
-    // eslint-disable-next-line no-unused-vars
-    function (req, res, next) {
+    (req, res, next) => {
       clearCache(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getApps", async function (req, res, next) {
+  router.use("/getApps", async (req, res, next) => {
     await getApps(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getApps`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getApps(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getAppSumsDBs", async function (req, res, next) {
+  router.use("/getAppSumsDBs", async (req, res, next) => {
     await getAppSumsDBs(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getAppSumsDBs`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getAppSumsDBs(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getModels", async function (req, res, next) {
+  router.use("/getModels", async (req, res, next) => {
     await getModels(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getModels`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getModels(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getRegions", async function (req, res, next) {
+  router.use("/getRegions", async (req, res, next) => {
     await getRegions(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getRegions`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getRegions(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getRegionsValuesMap", async function (req, res, next) {
+  router.use("/getRegionsValuesMap", async (req, res, next) => {
     await getRegionsValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getRegionsValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getRegionsValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getStatistics", async function (req, res, next) {
+  router.use("/getStatistics", async (req, res, next) => {
     await getStatistics(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getStatistics`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getStatistics(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getStatisticsValuesMap", async function (req, res, next) {
+  router.use("/getStatisticsValuesMap", async (req, res, next) => {
     await getStatisticsValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getStatisticsValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getStatisticsValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getVariables", async function (req, res, next) {
+  router.use("/getVariables", async (req, res, next) => {
     await getVariables(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getVariables`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getVariables(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getVariablesValuesMap", async function (req, res, next) {
+  router.use("/getVariablesValuesMap", async (req, res, next) => {
     await getVariablesValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getVariablesValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getVariablesValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getThresholds", async function (req, res, next) {
+  router.use("/getThresholds", async (req, res, next) => {
     await getThresholds(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getThresholds`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getThresholds(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getThresholdsValuesMap", async function (req, res, next) {
+  router.use("/getThresholdsValuesMap", async (req, res, next) => {
     await getThresholdsValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getThresholdsValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getThresholdsValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getScales", async function (req, res, next) {
+  router.use("/getScales", async (req, res, next) => {
     await getScales(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getScales`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getScales(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getScalesValuesMap", async function (req, res, next) {
+  router.use("/getScalesValuesMap", async (req, res, next) => {
     await getScalesValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getScalesValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getScalesValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getTruths", async function (req, res, next) {
+  router.use("/getTruths", async (req, res, next) => {
     await getTruths(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getTruths`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getTruths(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getTruthsValuesMap", async function (req, res, next) {
+  router.use("/getTruthsValuesMap", async (req, res, next) => {
     await getTruthsValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getTruthsValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getTruthsValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getFcstLengths", async function (req, res, next) {
+  router.use("/getFcstLengths", async (req, res, next) => {
     await getFcstLengths(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getFcstLengths`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getFcstLengths(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getFcstTypes", async function (req, res, next) {
+  router.use("/getFcstTypes", async (req, res, next) => {
     await getFcstTypes(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getFcstTypes`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getFcstTypes(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getFcstTypesValuesMap", async function (req, res, next) {
+  router.use("/getFcstTypesValuesMap", async (req, res, next) => {
     await getFcstTypesValuesMap(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getFcstTypesValuesMap`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getFcstTypesValuesMap(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getValidTimes", async function (req, res, next) {
+  router.use("/getValidTimes", async (req, res, next) => {
     await getValidTimes(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getValidTimes`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getValidTimes(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getLevels", async function (req, res, next) {
+  router.use("/getLevels", async (req, res, next) => {
     await getLevels(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getLevels`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getLevels(res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/getDates", async function (req, res, next) {
+  router.use("/getDates", async (req, res, next) => {
     await getDates(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/getDates`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await getDates(res);
     }
   );
 
-  // create picker routes for refreshMetaData
-  // eslint-disable-next-line no-unused-vars
-  router.use("/refreshMetadata", async function (req, res, next) {
+  router.use("/refreshMetadata", async (req, res, next) => {
     await refreshMetadataMWltData(res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/refreshMetadata`,
-    // eslint-disable-next-line no-unused-vars
-    async function (req, res, next) {
+    async (req, res, next) => {
       await refreshMetadataMWltData(res);
     }
   );
-  // eslint-disable-next-line no-unused-vars
-  router.use("/refreshScorecard/:docId", function (req, res, next) {
+
+  router.use("/refreshScorecard/:docId", (req, res, next) => {
     refreshScorecard(req.params, res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/refreshScorecard/:docId`,
-    // eslint-disable-next-line no-unused-vars
-    function (req, res, next) {
+    (req, res, next) => {
       refreshScorecard(req.params, res);
     }
   );
 
-  // eslint-disable-next-line no-unused-vars
-  router.use("/setStatusScorecard/:docId", function (req, res, next) {
+  router.use("/setStatusScorecard/:docId", (req, res, next) => {
     setStatusScorecard(req.params, req, res);
   });
 
   router.use(
     `${Meteor.settings.public.proxy_prefix_path}/:app/setStatusScorecard/:docId`,
-    // eslint-disable-next-line no-unused-vars
-    function (req, res, next) {
+    (req, res, next) => {
       setStatusScorecard(req.params, req, res);
     }
   );

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -2965,227 +2965,228 @@ if (Meteor.isServer) {
   const app = WebApp.express();
   const router = WebApp.express.Router();
 
-  router.use("/healthz", async (req, res) => {
+  router.get("/healthz", async (req, res) => {
     await getHealth(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/healthz`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/healthz`, async (req, res) => {
     await getHealth(res);
   });
 
-  router.use("/CSV/:f/:key/:m/:a", (req, res) => {
+  router.get("/CSV/:f/:key/:m/:a", (req, res) => {
     getCSV(req.params, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/CSV/:f/:key/:m/:a`, (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/CSV/:f/:key/:m/:a`, (req, res) => {
     getCSV(req.params, res);
   });
 
-  router.use("/JSON/:f/:key/:m/:a", (req, res) => {
+  router.get("/JSON/:f/:key/:m/:a", (req, res) => {
     getJSON(req.params, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/JSON/:f/:key/:m/:a`, (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/JSON/:f/:key/:m/:a`, (req, res) => {
     getJSON(req.params, res);
   });
 
-  router.use("/clearCache", (req, res) => {
+  router.get("/clearCache", (req, res) => {
     clearCache(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/clearCache`, (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/clearCache`, (req, res) => {
     clearCache(res);
   });
 
-  router.use("/getApps", async (req, res) => {
+  router.get("/getApps", async (req, res) => {
     await getApps(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getApps`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getApps`, async (req, res) => {
     await getApps(res);
   });
 
-  router.use("/getAppSumsDBs", async (req, res) => {
+  router.get("/getAppSumsDBs", async (req, res) => {
     await getAppSumsDBs(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getAppSumsDBs`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getAppSumsDBs`, async (req, res) => {
     await getAppSumsDBs(res);
   });
 
-  router.use("/getModels", async (req, res) => {
+  router.get("/getModels", async (req, res) => {
     await getModels(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getModels`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getModels`, async (req, res) => {
     await getModels(res);
   });
 
-  router.use("/getRegions", async (req, res) => {
+  router.get("/getRegions", async (req, res) => {
     await getRegions(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getRegions`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getRegions`, async (req, res) => {
     await getRegions(res);
   });
 
-  router.use("/getRegionsValuesMap", async (req, res) => {
+  router.get("/getRegionsValuesMap", async (req, res) => {
     await getRegionsValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getRegionsValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getRegionsValuesMap`, async (req, res) => {
     await getRegionsValuesMap(res);
   });
 
-  router.use("/getStatistics", async (req, res) => {
+  router.get("/getStatistics", async (req, res) => {
     await getStatistics(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getStatistics`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getStatistics`, async (req, res) => {
     await getStatistics(res);
   });
 
-  router.use("/getStatisticsValuesMap", async (req, res) => {
+  router.get("/getStatisticsValuesMap", async (req, res) => {
     await getStatisticsValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getStatisticsValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getStatisticsValuesMap`, async (req, res) => {
     await getStatisticsValuesMap(res);
   });
 
-  router.use("/getVariables", async (req, res) => {
+  router.get("/getVariables", async (req, res) => {
     await getVariables(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getVariables`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getVariables`, async (req, res) => {
     await getVariables(res);
   });
 
-  router.use("/getVariablesValuesMap", async (req, res) => {
+  router.get("/getVariablesValuesMap", async (req, res) => {
     await getVariablesValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getVariablesValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getVariablesValuesMap`, async (req, res) => {
     await getVariablesValuesMap(res);
   });
 
-  router.use("/getThresholds", async (req, res) => {
+  router.get("/getThresholds", async (req, res) => {
     await getThresholds(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getThresholds`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getThresholds`, async (req, res) => {
     await getThresholds(res);
   });
 
-  router.use("/getThresholdsValuesMap", async (req, res) => {
+  router.get("/getThresholdsValuesMap", async (req, res) => {
     await getThresholdsValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getThresholdsValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getThresholdsValuesMap`, async (req, res) => {
     await getThresholdsValuesMap(res);
   });
 
-  router.use("/getScales", async (req, res) => {
+  router.get("/getScales", async (req, res) => {
     await getScales(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getScales`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getScales`, async (req, res) => {
     await getScales(res);
   });
 
-  router.use("/getScalesValuesMap", async (req, res) => {
+  router.get("/getScalesValuesMap", async (req, res) => {
     await getScalesValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getScalesValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getScalesValuesMap`, async (req, res) => {
     await getScalesValuesMap(res);
   });
 
-  router.use("/getTruths", async (req, res) => {
+  router.get("/getTruths", async (req, res) => {
     await getTruths(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getTruths`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getTruths`, async (req, res) => {
     await getTruths(res);
   });
 
-  router.use("/getTruthsValuesMap", async (req, res) => {
+  router.get("/getTruthsValuesMap", async (req, res) => {
     await getTruthsValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getTruthsValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getTruthsValuesMap`, async (req, res) => {
     await getTruthsValuesMap(res);
   });
 
-  router.use("/getFcstLengths", async (req, res) => {
+  router.get("/getFcstLengths", async (req, res) => {
     await getFcstLengths(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getFcstLengths`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getFcstLengths`, async (req, res) => {
     await getFcstLengths(res);
   });
 
-  router.use("/getFcstTypes", async (req, res) => {
+  router.get("/getFcstTypes", async (req, res) => {
     await getFcstTypes(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getFcstTypes`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getFcstTypes`, async (req, res) => {
     await getFcstTypes(res);
   });
 
-  router.use("/getFcstTypesValuesMap", async (req, res) => {
+  router.get("/getFcstTypesValuesMap", async (req, res) => {
     await getFcstTypesValuesMap(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getFcstTypesValuesMap`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getFcstTypesValuesMap`, async (req, res) => {
     await getFcstTypesValuesMap(res);
   });
 
-  router.use("/getValidTimes", async (req, res) => {
+  router.get("/getValidTimes", async (req, res) => {
     await getValidTimes(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getValidTimes`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getValidTimes`, async (req, res) => {
     await getValidTimes(res);
   });
 
-  router.use("/getLevels", async (req, res) => {
+  router.get("/getLevels", async (req, res) => {
     await getLevels(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getLevels`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getLevels`, async (req, res) => {
     await getLevels(res);
   });
 
-  router.use("/getDates", async (req, res) => {
+  router.get("/getDates", async (req, res) => {
     await getDates(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/getDates`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/getDates`, async (req, res) => {
     await getDates(res);
   });
 
-  router.use("/refreshMetadata", async (req, res) => {
+  // users manually enter this URL to refresh the metadata
+  router.get("/refreshMetadata", async (req, res) => {
     await refreshMetadataMWltData(res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/refreshMetadata`, async (req, res) => {
+  router.get(`${proxyPrefixPath}/:app/refreshMetadata`, async (req, res) => {
     await refreshMetadataMWltData(res);
   });
 
-  router.use("/refreshScorecard/:docId", (req, res) => {
+  router.post("/refreshScorecard/:docId", (req, res) => {
     refreshScorecard(req.params, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/refreshScorecard/:docId`, (req, res) => {
+  router.post(`${proxyPrefixPath}/:app/refreshScorecard/:docId`, (req, res) => {
     refreshScorecard(req.params, res);
   });
 
-  router.use("/setStatusScorecard/:docId", (req, res) => {
+  router.post("/setStatusScorecard/:docId", (req, res) => {
     setStatusScorecard(req.params, req, res);
   });
 
-  router.use(`${proxyPrefixPath}/:app/setStatusScorecard/:docId`, (req, res) => {
+  router.post(`${proxyPrefixPath}/:app/setStatusScorecard/:docId`, (req, res) => {
     setStatusScorecard(req.params, req, res);
   });
 


### PR DESCRIPTION
This PR:

* Switches the routing to use arrow functions
* Simplifies the routing callsites by creating the `proxyPrefixPath` variable for `Meteor.settings.public.proxy_prefix_path`
* Switches the express router to use HTTP methods (`router.get`/`router.post`) instead of `router.use`
* Switches our liveness endpoint from `/status` to the standard `/healthz` endpoint and simplifies to return a `200` response. 