### PR TITLE
Clean up & simplify routing

### DIFF
--- a/meteor_packages/mats-common/imports/startup/api/routeRegistration.js
+++ b/meteor_packages/mats-common/imports/startup/api/routeRegistration.js
@@ -42,11 +42,10 @@ const handleRoute = async (route, req, res, next) => {
 /**
  * Registers all routes with the Express router
  * @param {Object} router - Express router instance
- * @param {string|null} prefix - Optional prefix for routes (e.g. '/mats', '/mats-int')
  */
-export const registerRoutes = (router, prefix = "") => {
+export const registerRoutes = (router) => {
   routes.forEach((route) => {
-    const path = prefix ? `${prefix}/:app${route.path}` : route.path;
+    const { path } = route;
 
     // Determine HTTP method (default to GET)
     const method = route.method?.toLowerCase() || "get";
@@ -65,6 +64,7 @@ export const registerRoutes = (router, prefix = "") => {
       default:
         throw new Error(`Unsupported HTTP method: ${method}`);
     }
+    console.log(`Registered route: ${method.toUpperCase()} ${path}`);
   });
 };
 
@@ -75,34 +75,15 @@ export const registerRoutes = (router, prefix = "") => {
 export const setupRouter = () => {
   if (!Meteor.isServer) return;
 
-  // set the default proxy prefix path to ""
-  // If the settings are not complete, they will be set by the configuration and written out, which will cause the app to reset
-  if (Meteor.settings.public && !Meteor.settings.public.proxy_prefix_path) {
-    Meteor.settings.public.proxy_prefix_path = "";
-  }
-
-  const proxyPrefixPath = Meteor.settings.public.proxy_prefix_path;
-
   // Create Express app and router
   const app = WebApp.express();
   const router = WebApp.express.Router();
 
-  // Register routes with or without prefix
-  if (!proxyPrefixPath) {
-    registerRoutes(router);
-  } else {
-    registerRoutes(router, proxyPrefixPath);
-  }
+  registerRoutes(router);
 
   // Mount router on app
   app.use("/", router);
 
   // Add router to WebApp handlers
   WebApp.handlers.use(app);
-
-  console.log(
-    `MATS API routes registered${
-      proxyPrefixPath ? ` with prefix ${proxyPrefixPath}` : ""
-    }`
-  );
 };

--- a/meteor_packages/mats-common/imports/startup/client/graph_util.js
+++ b/meteor_packages/mats-common/imports/startup/client/graph_util.js
@@ -2,27 +2,10 @@
  * Copyright (c) 2021 Colorado State University and Regents of the University of Colorado. All rights reserved.
  */
 
-import { Meteor } from "meteor/meteor";
-import { matsCollections, matsTypes, matsCurveUtils } from "meteor/randyp:mats-common";
+import { matsTypes, matsCurveUtils } from "meteor/randyp:mats-common";
 
 /* global $, Session */
 /* eslint-disable no-console */
-
-// get the app's base URL
-const getBaseURL = function () {
-  const urlComponents = document.location.href.split("/");
-  const baseURL =
-    Meteor.settings.public.home === undefined
-      ? `https://${urlComponents[2]}`
-      : Meteor.settings.public.home;
-  const appName =
-    matsCollections.Settings === undefined ||
-    matsCollections.Settings.findOne({}) === undefined ||
-    matsCollections.Settings.findOne({}).appName === undefined
-      ? `${urlComponents[urlComponents.length - 1]}`
-      : matsCollections.Settings.findOne({}).appName;
-  return { appName, baseURL };
-};
 
 // set the label for the hide show buttons (NO DATA) for the initial time here
 const setNoDataLabels = function (dataset) {
@@ -641,7 +624,6 @@ const downloadFile = function (fileURL, fileName) {
 
 // eslint-disable-next-line no-undef
 export default matsGraphUtils = {
-  getBaseURL,
   setNoDataLabels,
   setNoDataLabelsMap,
   width,

--- a/meteor_packages/mats-common/imports/startup/client/routes.js
+++ b/meteor_packages/mats-common/imports/startup/client/routes.js
@@ -30,14 +30,14 @@ FlowRouter.route("/", {
 FlowRouter.route("/CSV/:graphFunction/:key/:matching/:appName", {
   name: "csv",
   action() {
-    window.location.href = FlowRouter.current.path;
+    window.location.href = FlowRouter.current().path;
   },
 });
 
 FlowRouter.route("/JSON/:graphFunction/:key/:matching/:appName", {
   name: "json",
   action() {
-    window.location.href = FlowRouter.current.path;
+    window.location.href = FlowRouter.current().path;
   },
 });
 

--- a/meteor_packages/mats-common/imports/startup/client/routes.js
+++ b/meteor_packages/mats-common/imports/startup/client/routes.js
@@ -7,7 +7,7 @@ import { FlowRouter } from "meteor/ostrio:flow-router-extra";
 
 /* global Session */
 
-// localhost routes
+// Routes
 
 FlowRouter.route("/", {
   name: "main",
@@ -30,16 +30,14 @@ FlowRouter.route("/", {
 FlowRouter.route("/CSV/:graphFunction/:key/:matching/:appName", {
   name: "csv",
   action() {
-    // eslint-disable-next-line no-underscore-dangle
-    window.location.href = FlowRouter._current.path;
+    window.location.href = FlowRouter.current.path;
   },
 });
 
 FlowRouter.route("/JSON/:graphFunction/:key/:matching/:appName", {
   name: "json",
   action() {
-    // eslint-disable-next-line no-underscore-dangle
-    window.location.href = FlowRouter._current.path;
+    window.location.href = FlowRouter.current.path;
   },
 });
 
@@ -69,90 +67,7 @@ FlowRouter.route("/scorecardTimeseries/:key", {
   },
 });
 
-// appname routes
-FlowRouter.route(`${Meteor.settings.public.proxy_prefix_path}/:appName`, {
-  name: "main",
-  action() {
-    if (Meteor.settings.public.scorecard) {
-      this.render("scorecardHome");
-    } else if (Meteor.settings.public.custom) {
-      this.render("customHome");
-    } else if (
-      Meteor.settings.public.undefinedRoles !== undefined &&
-      Meteor.settings.public.undefinedRoles.length > 0
-    ) {
-      this.render("configure");
-    } else {
-      this.render("home");
-    }
-  },
-});
-
-FlowRouter.route(
-  `${Meteor.settings.public.proxy_prefix_path}/*/CSV/:graphFunction/:key/:matching/:appName`,
-  {
-    name: "csv",
-    action() {
-      // eslint-disable-next-line no-underscore-dangle
-      window.location.href = FlowRouter._current.path;
-    },
-  }
-);
-
-FlowRouter.route(
-  `${Meteor.settings.public.proxy_prefix_path}/*/JSON/:graphFunction/:key/:matching/:appName`,
-  {
-    name: "json",
-    action() {
-      // eslint-disable-next-line no-underscore-dangle
-      window.location.href = FlowRouter._current.path;
-    },
-  }
-);
-
-FlowRouter.route(
-  `${Meteor.settings.public.proxy_prefix_path}/*/preview/:graphFunction/:key/:matching/:appName`,
-  {
-    name: "preview",
-    action(params) {
-      this.render("graphStandAlone", params);
-    },
-  }
-);
-
-FlowRouter.route(
-  `${Meteor.settings.public.proxy_prefix_path}/*/scorecardDisplay/:userName/:name/:submitted/:processedAt`,
-  {
-    name: "scorecardDisplay",
-    action(params) {
-      this.render("scorecardDisplay", params);
-    },
-  }
-);
-
-FlowRouter.route(
-  `${Meteor.settings.public.proxy_prefix_path}/*/scorecardTimeseries/:key`,
-  {
-    name: "scorecardTimeseries",
-    action(params) {
-      Session.set("scorecardTimeseriesKey", params.key);
-      if (Meteor.settings.public.custom) {
-        this.render("customHome");
-      } else {
-        this.render("home");
-      }
-    },
-  }
-);
-
 // exception routes
-FlowRouter.route(`${Meteor.settings.public.proxy_prefix_path}/*/`, {
-  name: "main",
-  action() {
-    this.render("notFound");
-  },
-});
-
 FlowRouter.route("/*", {
   action() {
     this.render("notFound");

--- a/meteor_packages/mats-common/templates/graph/graph.js
+++ b/meteor_packages/mats-common/templates/graph/graph.js
@@ -1438,7 +1438,7 @@ Template.graph.events({
     const graphFunction = Session.get("graphFunction");
     const plotParameter = Session.get("plotParameter");
     const wind = window.open(
-      `${window.location}/preview/${graphFunction}/${key}/${plotParameter}/${appName}`,
+      `${window.location.href}/preview/${graphFunction}/${key}/${plotParameter}/${appName}`,
       "_blank",
       "status=no,titlebar=no,toolbar=no,scrollbars=no,menubar=no,resizable=yes",
       `height=${h},width=${w}`
@@ -1495,7 +1495,7 @@ Template.graph.events({
     const plotResultKey = Session.get("plotResultKey");
     const plotParameter = Session.get("plotParameter");
     window.open(
-      `${window.location}/JSON/${graphFunction}/${plotResultKey}/${plotParameter}/${appName}`,
+      `${window.location.href}/JSON/${graphFunction}/${plotResultKey}/${plotParameter}/${appName}`,
       "_blank",
       "resizable=yes"
     );

--- a/meteor_packages/mats-common/templates/graph/graph.js
+++ b/meteor_packages/mats-common/templates/graph/graph.js
@@ -1434,15 +1434,11 @@ Template.graph.events({
         w = h * 1.35;
         break;
     }
-    const urlParams = matsGraphUtils.getBaseURL();
-    let url = `${urlParams.baseURL}/${urlParams.appName}`;
-    if (urlParams.baseURL.includes("localhost")) {
-      url = `${urlParams.baseURL}`;
-    }
+    const appName = Meteor.settings.public.app;
     const graphFunction = Session.get("graphFunction");
     const plotParameter = Session.get("plotParameter");
     const wind = window.open(
-      `${url}/preview/${graphFunction}/${key}/${plotParameter}/${urlParams.appName}`,
+      `${window.location}/preview/${graphFunction}/${key}/${plotParameter}/${appName}`,
       "_blank",
       "status=no,titlebar=no,toolbar=no,scrollbars=no,menubar=no,resizable=yes",
       `height=${h},width=${w}`
@@ -1494,16 +1490,12 @@ Template.graph.events({
     return null;
   },
   "click .basis"() {
-    const urlParams = matsGraphUtils.getBaseURL();
-    let url = `${urlParams.baseURL}/${urlParams.appName}`;
-    if (urlParams.baseURL.includes("localhost")) {
-      url = `${urlParams.baseURL}`;
-    }
+    const appName = Meteor.settings.public.app;
     const graphFunction = Session.get("graphFunction");
     const plotResultKey = Session.get("plotResultKey");
     const plotParameter = Session.get("plotParameter");
     window.open(
-      `${url}/JSON/${graphFunction}/${plotResultKey}/${plotParameter}/${urlParams.appName}`,
+      `${window.location}/JSON/${graphFunction}/${plotResultKey}/${plotParameter}/${appName}`,
       "_blank",
       "resizable=yes"
     );

--- a/meteor_packages/mats-common/templates/textOutput/textOutput.js
+++ b/meteor_packages/mats-common/templates/textOutput/textOutput.js
@@ -1088,7 +1088,7 @@ Template.textOutput.events({
     const plotParameter = Session.get("plotParameter");
     // open a new window with
     window.open(
-      `${window.location}/CSV/${graphFunction}/${plotResultKey}/${plotParameter}/${appName}`
+      `${window.location.href}/CSV/${graphFunction}/${plotResultKey}/${plotParameter}/${appName}`
     );
   },
 });

--- a/meteor_packages/mats-common/templates/textOutput/textOutput.js
+++ b/meteor_packages/mats-common/templates/textOutput/textOutput.js
@@ -2,10 +2,10 @@
  * Copyright (c) 2021 Colorado State University and Regents of the University of Colorado. All rights reserved.
  */
 
+import { Meteor } from "meteor/meteor";
 import {
   matsCollections,
   matsCurveUtils,
-  matsGraphUtils,
   matsPlotUtils,
   matsTypes,
 } from "meteor/randyp:mats-common";
@@ -1082,17 +1082,13 @@ Template.textOutput.helpers({
 Template.textOutput.events({
   "click .export"() {
     Session.get("plotType");
-    const urlParams = matsGraphUtils.getBaseURL();
-    let url = `${urlParams.baseURL}/${urlParams.appName}`;
-    if (urlParams.baseURL.includes("localhost")) {
-      url = `${urlParams.baseURL}`;
-    }
+    const appName = Meteor.settings.public.app;
     const graphFunction = Session.get("graphFunction");
     const plotResultKey = Session.get("plotResultKey");
     const plotParameter = Session.get("plotParameter");
     // open a new window with
     window.open(
-      `${url}/CSV/${graphFunction}/${plotResultKey}/${plotParameter}/${urlParams.appName}`
+      `${window.location}/CSV/${graphFunction}/${plotResultKey}/${plotParameter}/${appName}`
     );
   },
 });

--- a/meteor_packages/mats-common/templates/topnav/top_nav.js
+++ b/meteor_packages/mats-common/templates/topnav/top_nav.js
@@ -2,39 +2,23 @@
  * Copyright (c) 2021 Colorado State University and Regents of the University of Colorado. All rights reserved.
  */
 import { Meteor } from "meteor/meteor";
-import { matsCollections, matsTypes, matsGraphUtils } from "meteor/randyp:mats-common";
+import { matsCollections, matsTypes } from "meteor/randyp:mats-common";
 import { Template } from "meteor/templating";
 
 /* global $ */
 
 Template.topNav.helpers({
   govLogo() {
-    const urlParams = matsGraphUtils.getBaseURL();
-    if (urlParams.baseURL.includes("localhost")) {
-      return `${urlParams.baseURL}/packages/randyp_mats-common/public/img/icon-dot-gov.svg`;
-    }
-    return `${urlParams.baseURL}/${urlParams.appName}/packages/randyp_mats-common/public/img/icon-dot-gov.svg`;
+    return `${window.location}/packages/randyp_mats-common/public/img/icon-dot-gov.svg`;
   },
   httpsLogo() {
-    const urlParams = matsGraphUtils.getBaseURL();
-    if (urlParams.baseURL.includes("localhost")) {
-      return `${urlParams.baseURL}/packages/randyp_mats-common/public/img/icon-https.svg`;
-    }
-    return `${urlParams.baseURL}/${urlParams.appName}/packages/randyp_mats-common/public/img/icon-https.svg`;
+    return `${window.location}/packages/randyp_mats-common/public/img/icon-https.svg`;
   },
   flagLogo() {
-    const urlParams = matsGraphUtils.getBaseURL();
-    if (urlParams.baseURL.includes("localhost")) {
-      return `${urlParams.baseURL}/packages/randyp_mats-common/public/img/us_flag_small.png`;
-    }
-    return `${urlParams.baseURL}/${urlParams.appName}/packages/randyp_mats-common/public/img/us_flag_small.png`;
+    return `${window.location}/packages/randyp_mats-common/public/img/us_flag_small.png`;
   },
   transparentGif() {
-    const urlParams = matsGraphUtils.getBaseURL();
-    if (urlParams.baseURL.includes("localhost")) {
-      return `${urlParams.baseURL}/packages/randyp_mats-common/public/img/noaa_transparent.png`;
-    }
-    return `${urlParams.baseURL}/${urlParams.appName}/packages/randyp_mats-common/public/img/noaa_transparent.png`;
+    return `${window.location}/packages/randyp_mats-common/public/img/noaa_transparent.png`;
   },
   emailText() {
     if (
@@ -80,7 +64,7 @@ Template.topNav.helpers({
   },
   productLink() {
     return Meteor.settings.public.home === undefined
-      ? `https://${document.location.href.split("/")[2]}`
+      ? `https://${window.location.href.split("/")[2]}`
       : Meteor.settings.public.home;
   },
   bugsText() {

--- a/meteor_packages/mats-common/templates/topnav/top_nav.js
+++ b/meteor_packages/mats-common/templates/topnav/top_nav.js
@@ -9,16 +9,16 @@ import { Template } from "meteor/templating";
 
 Template.topNav.helpers({
   govLogo() {
-    return `${window.location}/packages/randyp_mats-common/public/img/icon-dot-gov.svg`;
+    return `${window.location.href}/packages/randyp_mats-common/public/img/icon-dot-gov.svg`;
   },
   httpsLogo() {
-    return `${window.location}/packages/randyp_mats-common/public/img/icon-https.svg`;
+    return `${window.location.href}/packages/randyp_mats-common/public/img/icon-https.svg`;
   },
   flagLogo() {
-    return `${window.location}/packages/randyp_mats-common/public/img/us_flag_small.png`;
+    return `${window.location.href}/packages/randyp_mats-common/public/img/us_flag_small.png`;
   },
   transparentGif() {
-    return `${window.location}/packages/randyp_mats-common/public/img/noaa_transparent.png`;
+    return `${window.location.href}/packages/randyp_mats-common/public/img/noaa_transparent.png`;
   },
   emailText() {
     if (


### PR DESCRIPTION
The application was routing to two different paths when it didn't need to. Reduce our routing to just focus on the application root so that we don't register each route twice.