### PR TITLE
Fixed metadata update issue

### DIFF
--- a/meteor_packages/mats-common/imports/startup/api/matsHelpers.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsHelpers.js
@@ -11,14 +11,10 @@ import {
   matsTypes,
 } from "meteor/randyp:mats-common";
 import { _ } from "meteor/underscore";
-import { Mongo } from "meteor/mongo";
 import { moment } from "meteor/momentjs:moment";
 
 /* eslint-disable no-console */
 /* eslint-disable no-await-in-loop */
-
-// local collection used to keep the table update times for refresh - won't ever be synchronized or persisted.
-const metaDataTableUpdates = new Mongo.Collection(null);
 
 // private - used to see if the main page needs to update its selectors
 export const checkMetaDataRefresh = async function () {
@@ -35,7 +31,7 @@ export const checkMetaDataRefresh = async function () {
         }
      */
   let refresh = false;
-  const tableUpdates = await metaDataTableUpdates.find({}).fetchAsync();
+  const tableUpdates = await matsCollections.metaDataTableUpdates.find({}).fetchAsync();
   const settings = await matsCollections.Settings.findOneAsync();
   const dbType = settings !== undefined ? settings.dbType : matsTypes.DbTypes.mysql;
   for (let tui = 0; tui < tableUpdates.length; tui += 1) {
@@ -109,7 +105,7 @@ export const checkMetaDataRefresh = async function () {
         await global.appSpecificResetRoutines[ai]();
       }
       // remember that we updated ALL the metadata tables just now
-      await metaDataTableUpdates.updateAsync(
+      await matsCollections.metaDataTableUpdates.updateAsync(
         {
           _id: id,
         },

--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -30,8 +30,6 @@ import { checkMetaDataRefresh, getFlattenedResultData } from "./matsHelpers";
 
 // PRIVATE
 
-// local collection used to keep the table update times for refresh - won't ever be synchronized or persisted.
-const metaDataTableUpdates = new Mongo.Collection(null);
 // initialize collection used for pop-out window functionality
 const LayoutStoreCollection = new Mongo.Collection("LayoutStoreCollection");
 // initialize collection used to cache previously downsampled plots
@@ -885,7 +883,7 @@ const refreshMetaData = new ValidatedMethod({
         throw new Meteor.Error("Server error: ", e.message);
       }
     }
-    return metaDataTableUpdates.find({}).fetchAsync();
+    return matsCollections.metaDataTableUpdates.find({}).fetchAsync();
   },
 });
 
@@ -1148,10 +1146,11 @@ const resetApp = async function (appRef) {
         const metaDataRef = metaDataTables[mdti];
         metaDataRef.lastRefreshed = moment().format();
         if (
-          (await metaDataTableUpdates.find({ name: metaDataRef.name }).countAsync()) ===
-          0
+          (await matsCollections.metaDataTableUpdates
+            .find({ name: metaDataRef.name })
+            .countAsync()) === 0
         ) {
-          await metaDataTableUpdates.updateAsync(
+          await matsCollections.metaDataTableUpdates.updateAsync(
             {
               name: metaDataRef.name,
             },
@@ -1345,7 +1344,7 @@ const testGetMetaDataTableUpdates = new ValidatedMethod({
   name: "matsMethods.testGetMetaDataTableUpdates",
   validate: new SimpleSchema({}).validator(),
   async run() {
-    return metaDataTableUpdates.find({}).fetchAsync();
+    return matsCollections.metaDataTableUpdates.find({}).fetchAsync();
   },
 });
 
@@ -1424,9 +1423,9 @@ const testSetMetaDataTableUpdatesLastRefreshedBack = new ValidatedMethod({
   name: "matsMethods.testSetMetaDataTableUpdatesLastRefreshedBack",
   validate: new SimpleSchema({}).validator(),
   async run() {
-    const mtu = await metaDataTableUpdates.find({}).fetchAsync();
+    const mtu = await matsCollections.metaDataTableUpdates.find({}).fetchAsync();
     const id = mtu[0]._id;
-    await metaDataTableUpdates.updateAsync(
+    await matsCollections.metaDataTableUpdates.updateAsync(
       {
         _id: id,
       },
@@ -1436,7 +1435,7 @@ const testSetMetaDataTableUpdatesLastRefreshedBack = new ValidatedMethod({
         },
       }
     );
-    return metaDataTableUpdates.find({}).fetchAsync();
+    return matsCollections.metaDataTableUpdates.find({}).fetchAsync();
   },
 });
 

--- a/meteor_packages/mats-common/imports/startup/both/mats-collections.js
+++ b/meteor_packages/mats-common/imports/startup/both/mats-collections.js
@@ -27,6 +27,7 @@ for (let i = 0; i < params.length; i += 1) {
   paramCollections[currParam] = new Mongo.Collection(currParam);
 }
 
+const metaDataTableUpdates = new Mongo.Collection("metaDataTableUpdates");
 const CurveParamsInfo = new Mongo.Collection("CurveParamsInfo");
 const AppsToScore = new Mongo.Collection("AppsToScore");
 const Scatter2dParams = new Mongo.Collection("Scatter2dParams");
@@ -60,6 +61,7 @@ if (Meteor.isServer) {
 }
 
 const explicitCollections = {
+  metaDataTableUpdates,
   CurveParamsInfo,
   AppsToScore,
   Scatter2dParams,

--- a/meteor_packages/mats-common/imports/startup/client/init.js
+++ b/meteor_packages/mats-common/imports/startup/client/init.js
@@ -22,6 +22,7 @@ if (Meteor.isClient) {
   for (let i = 0; i < params.length; i += 1) {
     Meteor.subscribe(params[i]);
   }
+  Meteor.subscribe("metaDataTableUpdates");
   Meteor.subscribe("Scatter2dParams");
   Meteor.subscribe("CurveParamsInfo");
   Meteor.subscribe("AppsToScore");

--- a/meteor_packages/mats-common/imports/startup/server/publications.js
+++ b/meteor_packages/mats-common/imports/startup/server/publications.js
@@ -33,6 +33,13 @@ if (Meteor.isServer) {
     currParam = params[i];
     publishField(currParam);
   }
+  Meteor.publish("metaDataTableUpdates", function () {
+    const data = matsCollections.metaDataTableUpdates.find({});
+    if (data) {
+      return data;
+    }
+    return this.ready();
+  });
   Meteor.publish("CurveParamsInfo", function () {
     const data = matsCollections.CurveParamsInfo.find({});
     if (data) {


### PR DESCRIPTION
When matsMethods was split up, one local mongo collection became several local mongo collections that didn't talk to each other. I've changed them into one global mongo collection.