### PR TITLE
Fixed scorecard restore settings

### DIFF
--- a/meteor_packages/mats-common/imports/startup/api/matsMethods.js
+++ b/meteor_packages/mats-common/imports/startup/api/matsMethods.js
@@ -1324,10 +1324,10 @@ const saveSettings = new ValidatedMethod({
         created: moment().format("MM/DD/YYYY HH:mm:ss"),
         name: params.saveAs,
         data: params.p,
-        owner: !Meteor.userId() ? "anonymous" : Meteor.userId(),
+        owner: user,
         permission: params.permission,
         savedAt: new Date(),
-        savedBy: !(await Meteor.userAsync()) ? "anonymous" : user,
+        savedBy: user,
       }
     );
   },

--- a/meteor_packages/mats-common/lib/plot_util.js
+++ b/meteor_packages/mats-common/lib/plot_util.js
@@ -212,6 +212,41 @@ const restoreSettings = function (p) {
     matsParamUtils.setValueTextForParamName("dates", p.data.dates);
   }
 
+  // deal with scorecard fields if this is a scorecard restore
+  if (p.data["scorecard-name"] !== undefined) {
+    const scFields = [
+      "name-this-scorecard",
+      "scorecard-percent-stdv",
+      "major-source-color",
+      "major-threshold-by-percent",
+      "major-threshold-by-stdv",
+      "major-truth-color",
+      "minor-source-color",
+      "minor-threshold-by-percent",
+      "minor-threshold-by-stdv",
+      "minor-truth-color",
+      "scorecard-schedule-mode",
+      "relative-date-range-type",
+      "relative-date-range-value",
+      "scorecard-recurrence-interval",
+      "scorecard-ends-on",
+      "these-days-of-the-month",
+      "these-days-of-the-week",
+      "these-hours-of-the-day",
+      "these-months",
+    ];
+    for (let scfIdx = 0; scfIdx < scFields.length; scfIdx += 1) {
+      const scField = scFields[scfIdx];
+      if (
+        p.data[scField] !== undefined &&
+        p.data[scField] !== "" &&
+        p.data[scField] !== matsTypes.InputTypes.unused
+      ) {
+        matsParamUtils.setValueTextForParamName(scField, p.data[scField]);
+      }
+    }
+  }
+
   // reset the plotParams
   Session.set("Curves", p.data.curves);
   Session.set("PlotParams", p);

--- a/meteor_packages/mats-common/templates/plot/plot_list.js
+++ b/meteor_packages/mats-common/templates/plot/plot_list.js
@@ -2,7 +2,6 @@
  * Copyright (c) 2021 Colorado State University and Regents of the University of Colorado. All rights reserved.
  */
 
-import { Meteor } from "meteor/meteor";
 import {
   matsTypes,
   matsCollections,
@@ -120,7 +119,7 @@ Template.plotList.helpers({
       { fields: { name: 1, owner: 1, permission: 1 } }
     ).fetch();
     for (let i = 0; i < l.length; i += 1) {
-      if (l[i].owner === Meteor.userId() && l[i].permission === "private") {
+      if (l[i].permission === "private") {
         names.push(l[i].name);
       }
     }
@@ -138,9 +137,6 @@ Template.plotList.helpers({
       }
     }
     return names;
-  },
-  isOwner() {
-    return this.owner === Meteor.userId();
   },
 });
 

--- a/meteor_packages/mats-common/templates/scorecard/scorecardStatusPage.html
+++ b/meteor_packages/mats-common/templates/scorecard/scorecardStatusPage.html
@@ -96,11 +96,11 @@
                                 >
                                   View
                                 </th>
-                                <th
+                                <!-- <th
                                   class="bg-info-subtle border-top border-bottom border-black"
                                 >
                                   Drop
-                                </th>
+                                </th> -->
                                 <th
                                   class="bg-info-subtle border-top border-bottom border-black"
                                 >
@@ -132,7 +132,7 @@
                                     >display</a
                                   >
                                 </td>
-                                <td class="bg-white border-bottom border-black">
+                                <!-- <td class="bg-white border-bottom border-black">
                                   <button
                                     type="button"
                                     class="btn btn-danger btn-xs drop-sc-instance"
@@ -144,7 +144,7 @@
                                   >
                                     Drop
                                   </button>
-                                </td>
+                                </td> -->
                                 <td class="bg-white border-bottom border-black">
                                   <button
                                     type="button"

--- a/meteor_packages/mats-common/templates/scorecard/scorecardStatusPage.js
+++ b/meteor_packages/mats-common/templates/scorecard/scorecardStatusPage.js
@@ -190,9 +190,6 @@ Template.scorecardStatusPage.events({
         matsCurveUtils.resetPlotResultData();
         const p = { data: {} };
         p.data = plotParams.plotParams;
-        p.data.paramData = {};
-        p.data.paramData.curveParams = plotParams.plotParams.curves;
-        p.data.paramData.plotParams = plotParams.plotParams;
         matsPlotUtils.restoreSettings(p);
       })
       .catch(function (error) {


### PR DESCRIPTION
Dave's bug was caused by badly defined plot params and leftover Meteor.user() code. I also hid the "Drop Scorecard" button, because we're unsure if we want users to have that power yet.